### PR TITLE
Add env variable for wined3d, fix CheckEnvBool()

### DIFF
--- a/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
@@ -156,6 +156,10 @@ public class CompatibilityTools
         psi.UseShellExecute = false;
         psi.WorkingDirectory = workingDirectory;
 
+        if (EnvironmentSettings.IsWineD3D) {
+            wineD3D = true;
+        }
+        
         var wineEnviromentVariables = new Dictionary<string, string>();
         wineEnviromentVariables.Add("WINEPREFIX", Settings.Prefix.FullName);
         wineEnviromentVariables.Add("WINEDLLOVERRIDES", $"mscoree=n;d3d9,d3d11,d3d10core,dxgi={(wineD3D ? "b" : "n")}");

--- a/src/XIVLauncher.Common/EnvironmentSettings.cs
+++ b/src/XIVLauncher.Common/EnvironmentSettings.cs
@@ -9,6 +9,10 @@
         public static bool IsNoRunas => CheckEnvBool("XL_NO_RUNAS");
         public static bool IsIgnoreSpaceRequirements => CheckEnvBool("XL_NO_SPACE_REQUIREMENTS");
         public static bool IsWineD3D => CheckEnvBool("XL_FORCE_WINED3D");
-        private static bool CheckEnvBool(string var) => bool.Parse(System.Environment.GetEnvironmentVariable(var) ?? "false");
+        private static bool CheckEnvBool(string var)
+        {
+            var = (System.Environment.GetEnvironmentVariable(var) ?? "false").ToLower();
+            return (var.Equals("1") || var.Equals("true") || var.Equals("on") || var.Equals("yes"));
+        }
     }
 }

--- a/src/XIVLauncher.Common/EnvironmentSettings.cs
+++ b/src/XIVLauncher.Common/EnvironmentSettings.cs
@@ -8,6 +8,7 @@
         public static bool IsPreRelease => CheckEnvBool("XL_PRERELEASE");
         public static bool IsNoRunas => CheckEnvBool("XL_NO_RUNAS");
         public static bool IsIgnoreSpaceRequirements => CheckEnvBool("XL_NO_SPACE_REQUIREMENTS");
+        public static bool IsWineD3D => CheckEnvBool("XL_FORCE_WINED3D");
         private static bool CheckEnvBool(string var) => bool.Parse(System.Environment.GetEnvironmentVariable(var) ?? "false");
     }
 }


### PR DESCRIPTION
Adds an environment variable, XL_FORCE_WINED3D, to force the use of wined3d instead of dxvk. While I was at it, I changed the function for CheckEnvBool(). Before, it would crash if you set one of the XL environment variables to something other than "true" or "false" or nothing. So XL_WINEONLINUX=1 would crash. Now valid values are true, 1, on, and yes. Everything else will evaluate to false.