### PR TITLE
Added MangoHud support

### DIFF
--- a/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
@@ -170,13 +170,34 @@ public class CompatibilityTools
         wineEnviromentVariables.Add("XL_WINEONLINUX", "true");
         string ldPreload = Environment.GetEnvironmentVariable("LD_PRELOAD") ?? "";
 
-        string dxvkHud = hudType switch
+        string dxvkHud = "0";
+        string mangoHud = "0";
+        bool mangoFull = false;
+        switch(hudType)
         {
-            Dxvk.DxvkHudType.None => "0",
-            Dxvk.DxvkHudType.Fps => "fps",
-            Dxvk.DxvkHudType.Full => "full",
-            _ => throw new ArgumentOutOfRangeException()
-        };
+            case Dxvk.DxvkHudType.None:
+                // Do nothing, already set.
+                break;
+            case Dxvk.DxvkHudType.Fps:
+                dxvkHud = "fps";
+                break;
+            case Dxvk.DxvkHudType.Full:
+                dxvkHud = "full";
+                break;
+            case Dxvk.DxvkHudType.Mango:
+                mangoHud = "1";
+                break;
+            case Dxvk.DxvkHudType.MangoFull:
+                mangoHud = "1";
+                mangoFull = true;
+                break;
+            default:
+                // Just in case
+                dxvkHud = "0";
+                mangoHud = "0";
+                mangoFull = false;
+                break;
+        }
 
         if (this.gamemodeOn == true && !ldPreload.Contains("libgamemodeauto.so.0"))
         {
@@ -184,6 +205,11 @@ public class CompatibilityTools
         }
 
         wineEnviromentVariables.Add("DXVK_HUD", dxvkHud);
+        wineEnviromentVariables.Add("MANGOHUD", mangoHud);
+        if (mangoFull)
+        {
+            wineEnviromentVariables.Add("MANGOHUD_CONFIG","full");
+        }
         wineEnviromentVariables.Add("DXVK_ASYNC", dxvkAsyncOn);
         wineEnviromentVariables.Add("WINEESYNC", Settings.EsyncOn);
         wineEnviromentVariables.Add("WINEFSYNC", Settings.FsyncOn);

--- a/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
@@ -172,11 +172,16 @@ public class CompatibilityTools
 
         string dxvkHud = "0";
         string mangoHud = "0";
+        bool useOverlayVars = true;
         bool mangoFull = false;
         switch(hudType)
         {
+            // Just pass through default values. Overlays cannot be turned on by user env variables.
+            case Dxvk.DxvkHudType.Off:
+                break;
+            // Don't set ENV vars. Allows user to pass through ENV vars manually from terminal/script.
             case Dxvk.DxvkHudType.None:
-                // Do nothing, already set.
+                useOverlayVars = false;
                 break;
             case Dxvk.DxvkHudType.Fps:
                 dxvkHud = "fps";
@@ -184,17 +189,16 @@ public class CompatibilityTools
             case Dxvk.DxvkHudType.Full:
                 dxvkHud = "full";
                 break;
-            case Dxvk.DxvkHudType.Mango:
+            case Dxvk.DxvkHudType.MangoHud:
                 mangoHud = "1";
                 break;
-            case Dxvk.DxvkHudType.MangoFull:
+            case Dxvk.DxvkHudType.MangoHudFull:
                 mangoHud = "1";
                 mangoFull = true;
                 break;
+            // Just in case, don't set any env variables.
             default:
-                // Just in case
-                dxvkHud = "0";
-                mangoHud = "0";
+                useOverlayVars = false;
                 mangoFull = false;
                 break;
         }
@@ -204,8 +208,11 @@ public class CompatibilityTools
             ldPreload = ldPreload.Equals("") ? "libgamemodeauto.so.0" : ldPreload + ":libgamemodeauto.so.0";
         }
 
-        wineEnviromentVariables.Add("DXVK_HUD", dxvkHud);
-        wineEnviromentVariables.Add("MANGOHUD", mangoHud);
+        if (useOverlayVars)
+        {
+            wineEnviromentVariables.Add("DXVK_HUD", dxvkHud);
+            wineEnviromentVariables.Add("MANGOHUD", mangoHud);
+        }
         if (mangoFull)
         {
             wineEnviromentVariables.Add("MANGOHUD_CONFIG","full");

--- a/src/XIVLauncher.Common.Unix/Compatibility/Dxvk.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/Dxvk.cs
@@ -46,20 +46,23 @@ public static class Dxvk
 
     public enum DxvkHudType
     {
-        [SettingsDescription("No Overlay", "Show nothing")]
+        [SettingsDescription("Disable DXVK Hud and MangoHud", "Turn off DXVK Hud and MangoHud")]
+        Off,
+
+        [SettingsDescription("Manual (use environment variables)", "User must set their own environment variables.")]
         None,
 
-        [SettingsDescription("DxvkHud FPS", "Only show FPS")]
+        [SettingsDescription("DXVK Hud FPS", "Only show FPS")]
         Fps,
 
-        [SettingsDescription("DxvkHud Full", "Show everything")]
+        [SettingsDescription("DXVK Hud Full", "Show everything")]
         Full,
 
         [SettingsDescription("MangoHud Default", "Uses ~/.config/MangoHud/wine-ffxiv_dx11.conf if present")]
-        Mango,
+        MangoHud,
 
         [SettingsDescription("MangoHud Full", "Show (almost) everything")]
-        MangoFull,
+        MangoHudFull,
     }
 
     private static void SetDxvkVersion()

--- a/src/XIVLauncher.Common.Unix/Compatibility/Dxvk.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/Dxvk.cs
@@ -46,14 +46,20 @@ public static class Dxvk
 
     public enum DxvkHudType
     {
-        [SettingsDescription("None", "Show nothing")]
+        [SettingsDescription("No Overlay", "Show nothing")]
         None,
 
-        [SettingsDescription("FPS", "Only show FPS")]
+        [SettingsDescription("DxvkHud FPS", "Only show FPS")]
         Fps,
 
-        [SettingsDescription("Full", "Show everything")]
+        [SettingsDescription("DxvkHud Full", "Show everything")]
         Full,
+
+        [SettingsDescription("MangoHud Default", "Uses ~/.config/MangoHud/wine-ffxiv_dx11.conf if present")]
+        Mango,
+
+        [SettingsDescription("MangoHud Full", "Show (almost) everything")]
+        MangoFull,
     }
 
     private static void SetDxvkVersion()

--- a/src/XIVLauncher.Common.Unix/Compatibility/Dxvk.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/Dxvk.cs
@@ -46,10 +46,10 @@ public static class Dxvk
 
     public enum DxvkHudType
     {
-        [SettingsDescription("Disable DXVK Hud and MangoHud", "Turn off DXVK Hud and MangoHud")]
+        [SettingsDescription("None", "Completely disable DXVK Hud and MangoHud")]
         Off,
 
-        [SettingsDescription("Manual (use environment variables)", "User must set their own environment variables.")]
+        [SettingsDescription("Manual", "User must set their own environment variables.")]
         None,
 
         [SettingsDescription("DXVK Hud FPS", "Only show FPS")]
@@ -58,7 +58,7 @@ public static class Dxvk
         [SettingsDescription("DXVK Hud Full", "Show everything")]
         Full,
 
-        [SettingsDescription("MangoHud Default", "Uses ~/.config/MangoHud/wine-ffxiv_dx11.conf if present")]
+        [SettingsDescription("MangoHud", "Uses ~/.config/MangoHud/wine-ffxiv_dx11.conf if present")]
         MangoHud,
 
         [SettingsDescription("MangoHud Full", "Show (almost) everything")]
@@ -91,6 +91,6 @@ public enum DxvkVersion
     [SettingsDescription("1.10.3", "Newer version of 1.10 branch of DXVK. Probably works.")]
     v1_10_3,
 
-    [SettingsDescription("2.0 (might break Dalamud, GShade)", "Newest version of DXVK. Might break Dalamud or GShade.")]
+    [SettingsDescription("2.0 (unstable)", "Newest version of DXVK. Might break Dalamud or GShade.")]
     v2_0,
 }


### PR DESCRIPTION
Added MangoHud to the DxvkHudType enum. Supports new options: None -> disables huds, Manual -> user needs to set own env variables, MangoHud -> sets MANGOHUD=1, MangoHud Full -> also sets MANGOHUD_CONFIG=full.