### PR TITLE
Compatibility Rework with DLSS handling

### DIFF
--- a/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
@@ -184,7 +184,7 @@ public class CompatibilityTools
             }
         }
     }
-
+    
     private void UninstallNvngx()
     {
         File.Delete(Path.Combine(GamePath.FullName, "game", "nvngx.dll"));

--- a/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
@@ -117,7 +117,7 @@ public class CompatibilityTools
         var dxvkPath = Path.Combine(dxvkDirectory.FullName, DxvkSettings.NvapiFolderName, "x64");
         if (!Directory.Exists(dxvkPath))
         {
-            Log.Information($"DXVK Nvapi does not exist, downloading {DxvkSettings.DownloadNvapiUrl}");
+            Log.Information($"DXVK Nvapi does not exist, downloading {DxvkSettings.NvapiDownloadUrl}");
             await DownloadTool(dxvkDirectory, DxvkSettings.DownloadUrl).ConfigureAwait(false);
         }
 

--- a/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
@@ -284,7 +284,8 @@ public class CompatibilityTools
 
         var wineEnvironmentVariables = new Dictionary<string, string>();
         wineEnvironmentVariables.Add("WINEPREFIX", Settings.Prefix.FullName);
-        wineEnvironmentVariables.Add("WINEDLLOVERRIDES", $"msquic=,mscoree=n,b;d3d9,d3d11,d3d10core,dxgi={(wineD3D ? "b" : "n,b")}");
+        wineEnvironmentVariables.Add("WINEDLLOVERRIDES", $"msquic=,mscoree=n,b;d3d9,d3d11,d3d10core,dxgi={(wineD3D ? "b" : "n,b")};{Settings.ExtraWineDLLOverrides}");
+        Console.WriteLine("WINEDLLOVERRIDES=\"" + wineEnvironmentVariables["WINEDLLOVERRIDES"] + "\"");
 
         if (!string.IsNullOrEmpty(Settings.DebugVars))
         {

--- a/src/XIVLauncher.Common.Unix/Compatibility/DxvkSettings.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/DxvkSettings.cs
@@ -22,9 +22,11 @@ public class DxvkSettings
 
     public bool NvapiEnabled { get; }
 
+    public bool NvngxOverride { get; }
+
     public Dictionary<string, string> Environment { get; }
 
-    public DxvkSettings(string folder, string url, string storageFolder, bool async, int maxFrameRate, bool dxvkHudEnabled, string dxvkHudString, bool mangoHudEnabled = false, bool mangoHudCustomIsFile = false, string customMangoHud = "", bool enabled = true, string nvapiFolder = "", string nvapiUrl = "", string nvngxFolder = "")
+    public DxvkSettings(string folder, string url, string storageFolder, bool async, int maxFrameRate, bool dxvkHudEnabled, string dxvkHudString, bool mangoHudEnabled = false, bool mangoHudCustomIsFile = false, string customMangoHud = "", bool enabled = true, string nvapiFolder = "", string nvapiUrl = "", string nvngxFolder = "", bool nvngxOverride = false)
     {
         FolderName = folder;
         DownloadUrl = url;
@@ -32,6 +34,7 @@ public class DxvkSettings
         NvapiDownloadUrl = nvapiUrl;
         NvngxFolder = nvngxFolder;
         Enabled = enabled;
+        NvngxOverride = nvngxOverride;
 
         // Disable Nvapi if the NvapiFolderName is empty, if Dxvk is not enabled, or if the dxvk version is dxvk-1.x or dxvk-async-1.x
         NvapiEnabled = (!string.IsNullOrEmpty(NvapiFolderName) && DxvkAllowsNvapi(FolderName) && Enabled);

--- a/src/XIVLauncher.Common.Unix/Compatibility/DxvkSettings.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/DxvkSettings.cs
@@ -26,7 +26,7 @@ public class DxvkSettings
 
     public Dictionary<string, string> Environment { get; }
 
-    public DxvkSettings(string folder, string url, string storageFolder, bool async, int maxFrameRate, bool dxvkHudEnabled, string dxvkHudString, bool mangoHudEnabled = false, bool mangoHudCustomIsFile = false, string customMangoHud = "", bool enabled = true, string nvapiFolder = "", string nvapiUrl = "", string nvngxFolder = "", bool nvngxOverride = false)
+    public DxvkSettings(string folder, string url, string storageFolder, bool async, int maxFrameRate, bool dxvkHudEnabled, string dxvkHudString, bool mangoHudEnabled = false, bool mangoHudCustomIsFile = false, string customMangoHud = "", bool enabled = true, string nvapiFolder = "", string nvapiUrl = "", string nvngxFolder = "")
     {
         FolderName = folder;
         DownloadUrl = url;
@@ -34,7 +34,7 @@ public class DxvkSettings
         NvapiDownloadUrl = nvapiUrl;
         NvngxFolder = nvngxFolder;
         Enabled = enabled;
-        NvngxOverride = nvngxOverride;
+        NvngxOverride = !string.IsNullOrEmpty(NvapiFolderName) && string.IsNullOrEmpty(NvngxFolder);
 
         // Disable Nvapi if the NvapiFolderName is empty, if Dxvk is not enabled, or if the dxvk version is dxvk-1.x or dxvk-async-1.x
         NvapiEnabled = (!string.IsNullOrEmpty(NvapiFolderName) && DxvkAllowsNvapi(FolderName) && Enabled);

--- a/src/XIVLauncher.Common.Unix/Compatibility/DxvkSettings.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/DxvkSettings.cs
@@ -35,8 +35,6 @@ public class DxvkSettings
 
         // Disable Nvapi if the NvapiFolderName is empty, if Dxvk is not enabled, or if the dxvk version is dxvk-1.x or dxvk-async-1.x
         NvapiEnabled = (!string.IsNullOrEmpty(NvapiFolderName) && DxvkAllowsNvapi(FolderName) && Enabled);
-        System.Console.WriteLine($"NvapiEnabled = {NvapiEnabled}");
-
 
         var dxvkConfigPath = new DirectoryInfo(Path.Combine(storageFolder, "compatibilitytool", "dxvk"));
         Environment = new Dictionary<string, string>

--- a/src/XIVLauncher.Common.Unix/Compatibility/DxvkSettings.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/DxvkSettings.cs
@@ -14,12 +14,23 @@ public class DxvkSettings
 
     public string DownloadUrl { get; }
 
+    public string NvapiFolderName { get; }
+
+    public string NvapiDownloadUrl { get; }
+
+    public string NvngxFolder { get; }
+
+    public bool NvapiEnabled => !string.IsNullOrEmpty(NvapiFolderName) && Enabled;
+
     public Dictionary<string, string> Environment { get; }
 
-    public DxvkSettings(string folder, string url, string storageFolder, bool async, int maxFrameRate, bool dxvkHudEnabled, string dxvkHudString, bool mangoHudEnabled = false, bool mangoHudCustomIsFile = false, string customMangoHud = "", bool enabled = true)
+    public DxvkSettings(string folder, string url, string storageFolder, bool async, int maxFrameRate, bool dxvkHudEnabled, string dxvkHudString, bool mangoHudEnabled = false, bool mangoHudCustomIsFile = false, string customMangoHud = "", bool enabled = true, string nvapiFolder = "", string nvapiUrl = "", string nvngxFolder = "")
     {
         FolderName = folder;
         DownloadUrl = url;
+        NvapiFolderName = nvapiFolder;
+        NvapiDownloadUrl = nvapiUrl;
+        NvngxFolder = nvngxFolder;
         Enabled = enabled;
 
         var dxvkConfigPath = new DirectoryInfo(Path.Combine(storageFolder, "compatibilitytool", "dxvk"));
@@ -56,6 +67,12 @@ public class DxvkSettings
             {
                 Environment.Add("MANGOHUD_CONFIG", customMangoHud);
             }
+        }
+
+        if (!string.IsNullOrEmpty(NvapiFolderName))
+        {
+            Environment.Add("DXVK_ENABLE_NVAPI", "1");
+            Environment.Add("DXKV_CONFIG", "dxgi.nvapiHack = False; dxgi.hideNvidiaGpu = False");
         }
     }
 

--- a/src/XIVLauncher.Common.Unix/Compatibility/WineSettings.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/WineSettings.cs
@@ -1,4 +1,7 @@
 ﻿using System.IO;
+using System.Text.RegularExpressions;
+using System.Linq;
+
 
 namespace XIVLauncher.Common.Unix.Compatibility;
 
@@ -16,6 +19,8 @@ public class WineSettings
 
     public string DownloadUrl;
 
+    public string ExtraWineDLLOverrides;
+
     public string EsyncOn { get; private set; }
 
     public string FsyncOn { get; private set; }
@@ -26,18 +31,31 @@ public class WineSettings
 
     public DirectoryInfo Prefix { get; private set; }
 
-    public WineSettings(bool isManaged, string customBinPath, string managedFolder, string managedUrl, DirectoryInfo storageFolder, string debugVars, FileInfo logFile, DirectoryInfo prefix, bool? esyncOn, bool? fsyncOn)
+    public WineSettings(bool isManaged, string customBinPath, string managedFolder, string managedUrl, string extraDLLOverrides, DirectoryInfo storageFolder, string debugVars, FileInfo logFile, DirectoryInfo prefix, bool? esyncOn, bool? fsyncOn)
     {
         // storageFolder is the path to .xlcore folder. managedFolder is the foldername inside the tarball that will be downloaded from managedUrl.
         IsManaged = isManaged;
         FolderName = managedFolder;
         DownloadUrl = managedUrl;
         BinPath = (isManaged) ? Path.Combine(storageFolder.FullName, "compatibilitytool", "wine", managedFolder, "bin") : customBinPath;
+        ExtraWineDLLOverrides = WineDLLOverrideIsValid(extraDLLOverrides) ? extraDLLOverrides ?? "" : "";
 
         this.EsyncOn = (esyncOn ?? false) ? "1" : "0";
         this.FsyncOn = (fsyncOn ?? false) ? "1" : "0";
         this.DebugVars = debugVars;
         this.LogFile = logFile;
         this.Prefix = prefix;
+    }
+
+    public static bool WineDLLOverrideIsValid(string dlls)
+    {
+        string[] invalid = { "msquic", "mscoree", "d3d9", "d3d11", "d3d10core", "dxgi" };
+        var format = @"^(?:(?:[a-zA-Z0-9_\-\.]+,?)+=(?:n,b|b,n|n|b|d|,|);?)+$";
+
+        if (string.IsNullOrEmpty(dlls)) return true;
+        if (invalid.Any(s => dlls.Contains(s))) return false;
+        if (Regex.IsMatch(dlls, format)) return true;
+
+        return false;
     }
 }


### PR DESCRIPTION
This is the compatiblity rework 2 with added patches for DLSS. It adds dxvk-nvapi and nvidia nvngx.dll handling, as well as a field for extra WINEDLLOVERRIDES. This will allow users to pass in extra windows dlls for reshade and other things. Most notably, the DLSS quality mod and FSR2 replacement mod both require passing a few extra dll overrides. Formatting is checked via the WineSettings.WineDLLOverrideIsValid() function. The "Enable DLSS" option will not appear if the nvngx.dll file cannot be found.

The launcher will search for nvngx.dll so the user does not have to do anything extra. It will search, in order, ~/.xlcore/compatibilitytool/nvidia, /lib64, /lib, /usr/lib64, and /usr/lib. As soon as it finds one, it will stop searching. This does work with flatpaks as well. The nvngx.dll and _nvngx.dll will be symlinked into the FFXIV game folder. They can't be placed in the prefix because the game will hang at a black window. 

DLSS requires a newer version of wine. 9.0 and later should work, as well as most wine-ge builds >= 8 and my valvebe builds>= 8. It also requres DXVK >= 2.0. And a compatible nvidia gpu, of course.

This can be merged as is, or merged later over the top of PR #1366 (Compatibility rework 2). This requires the "Compatibility Rework with DLSS handling" PR in XIVLauncher.Core to be merged.